### PR TITLE
Fix error in Django 5.2

### DIFF
--- a/lti_authentication/backends.py
+++ b/lti_authentication/backends.py
@@ -3,7 +3,12 @@ from logging import getLogger
 
 from django.contrib.auth import get_user_model
 from django.contrib.auth.backends import ModelBackend
-from django.utils.deprecation import RemovedInDjango50Warning  # type: ignore
+
+try:
+    from django.utils.deprecation import RemovedInDjango50Warning  # type: ignore
+except ImportError:
+    pass
+
 from django.utils.inspect import func_supports_parameter
 from lti_tool.types import LtiLaunch
 
@@ -66,11 +71,12 @@ class LtiLaunchAuthenticationBackend(ModelBackend):
         if func_supports_parameter(self.configure_user, "created"):
             user = self.configure_user(request, user, created=created)
         else:
-            warnings.warn(
-                f"`created=True` must be added to the signature of "
-                f"{self.__class__.__qualname__}.configure_user().",
-                category=RemovedInDjango50Warning,
-            )
+            if RemovedInDjango50Warning:
+                warnings.warn(
+                    f"`created=True` must be added to the signature of "
+                    f"{self.__class__.__qualname__}.configure_user().",
+                    category=RemovedInDjango50Warning,
+                )
             if created:
                 user = self.configure_user(request, user)
         return user if self.user_can_authenticate(user) else None


### PR DESCRIPTION
Using this package in django 5.2 throws this error, since it looks like this warning module was removed.
```
File "ve/lib64/python3.13/site-packages/lti_authentication/backends.py", line 7, in <module>
  from django.utils.deprecation import RemovedInDjango50Warning  # type: ignore
ImportError: cannot import name 'RemovedInDjango50Warning' from 'django.utils.deprecation' (ve/lib64/python3.13/site-packages/django/utils/deprecation.py)
```

This change adds a graceful fallback for this code.