### PR TITLE
Add a path_prefix option

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,16 @@ MIDDLEWARE = [
 ]
 ```
 
+Optionally, you can define a `path_prefix` to only allow certain
+routes of your Django application to be authenticated with
+django-lti-authentication:
+
+```
+LTI_AUTHENTICATION = {
+    'path_prefix': '/lti/',
+}
+```
+
 Configuring the Django username
 -------------------------------
 

--- a/lti_authentication/middleware.py
+++ b/lti_authentication/middleware.py
@@ -31,6 +31,12 @@ class LtiLaunchAuthenticationMiddleware(MiddlewareMixin):
     force_logout_if_no_launch = True
 
     def process_request(self, request):
+        path_prefix = settings.LTI_AUTHENTICATION.get('path_prefix')
+        if path_prefix and not request.path.startswith(path_prefix):
+            # This request is outside of path_prefix and therefore not
+            # authenticated with django-lti-auth.
+            return
+
         # AuthenticationMiddleware is required so that request.user exists.
         if not hasattr(request, "user"):
             raise ImproperlyConfigured(


### PR DESCRIPTION
This is an idea that I would find useful in my application. I'm open to other ideas on the exact implementation, but I basically want to allow only certain parts of my application to use django-lti-authentication. The default setup enables django-lti-authentication for every request, but there are many cases where we only want to enable LTI auth for certain routes, such as the LTI launch route.